### PR TITLE
websocket-client: set client-role to universal

### DIFF
--- a/xposed/src/main/java/moe/fuqiuluo/xposed/actions/InitRemoteService.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/xposed/actions/InitRemoteService.kt
@@ -62,6 +62,7 @@ internal class InitRemoteService: IAction {
                 val runtime = MobileQQ.getMobileQQ().waitAppRuntime()
                 val curUin = runtime.currentAccountUin
                 val wsHeaders = hashMapOf(
+                    "X-Client-Role" to "Universal",
                     "X-Self-ID" to curUin
                 )
                 val token = ShamrockConfig.getToken()


### PR DESCRIPTION
根据 [OneBot 11 - 连接请求](https://github.com/botuniverse/onebot-11/blob/master/communication/ws-reverse.md#%E8%BF%9E%E6%8E%A5%E8%AF%B7%E6%B1%82) 

在建立反向 Websocket 连接时应携带 `X-Client-Role: Universal` 请求头

部分实现（如 [satori](https://github.com/satorijs/satori/blob/master/adapters/onebot/src/ws.ts#L49-L51)）会检查此请求头导致连接失败

