### PR TITLE
使用api配置过滤消息，满足条件的消息推送

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.2" apply false
+    id("com.android.application") version "8.0.2" apply false
     id("org.jetbrains.kotlin.android") version "1.8.10" apply false
-    id("com.android.library") version "8.1.2" apply false
+    id("com.android.library") version "8.0.2" apply false
     //id("io.realm.kotlin") version "1.11.0" apply false
 }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/action/ActionManager.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/action/ActionManager.kt
@@ -8,6 +8,7 @@ import moe.fuqiuluo.shamrock.remote.action.handlers.*
 import moe.fuqiuluo.shamrock.remote.entries.EmptyObject
 import moe.fuqiuluo.shamrock.remote.entries.Status
 import moe.fuqiuluo.shamrock.remote.entries.resultToString
+import moe.fuqiuluo.shamrock.remote.service.api.WebSocketClientServlet
 import moe.fuqiuluo.shamrock.tools.*
 import moe.fuqiuluo.shamrock.tools.json
 
@@ -41,7 +42,7 @@ internal object ActionManager {
             GetWeatherCityCode, GetWeather,
 
             // OTHER
-            GetDeviceBattery
+            GetDeviceBattery, SetAllowPushRuleConfig
         ).forEach {
             it.alias.forEach { name ->
                 actionMap[name] = it
@@ -108,10 +109,12 @@ internal abstract class IActionHandler {
 internal class ActionSession {
     private val params: JsonObject
     internal val echo: String
+    internal val webSocket: WebSocketClientServlet?
 
     constructor(
         values: Map<String, Any?>,
-        echo: String = ""
+        echo: String = "",
+        webSocket: WebSocketClientServlet? = null
     ) {
         val map = hashMapOf<String, JsonElement>()
         values.forEach { (key, value) ->
@@ -129,14 +132,17 @@ internal class ActionSession {
         }
         this.echo = echo
         this.params = JsonObject(map)
+        this.webSocket = webSocket
     }
 
     constructor(
         params: JsonObject,
-        echo: String = ""
+        echo: String = "",
+        webSocket: WebSocketClientServlet? = null
     ) {
         this.echo = echo
         this.params = params
+        this.webSocket = webSocket
     }
 
     fun getLong(key: String): Long {

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/action/handlers/SetAllowPushRuleConfig.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/action/handlers/SetAllowPushRuleConfig.kt
@@ -1,0 +1,44 @@
+package moe.fuqiuluo.shamrock.remote.action.handlers
+
+import kotlinx.serialization.json.JsonArray
+import moe.fuqiuluo.shamrock.remote.action.ActionSession
+import moe.fuqiuluo.shamrock.remote.action.IActionHandler
+import moe.fuqiuluo.shamrock.remote.service.api.WebSocketClientServlet
+import moe.fuqiuluo.shamrock.tools.asJsonObjectOrNull
+import moe.fuqiuluo.shamrock.tools.asStringOrNull
+
+internal object SetAllowPushRuleConfig : IActionHandler() {
+    override suspend fun internalHandle(session: ActionSession): String {
+        return invoke(session.getArray("allow"), session.echo, session.webSocket)
+    }
+
+    override fun path(): String = "set_allow_push_rule_config"
+
+    override val requiredParams: Array<String> = arrayOf("allow")
+
+    operator fun invoke(
+        allow: JsonArray,
+        echo: String = "",
+        webSocket: WebSocketClientServlet?
+    ): String {
+        webSocket?.also { ws ->
+            ws.clearPushRule(false)
+            allow.forEach {
+                val asJsonObjectOrNull = it.asJsonObjectOrNull
+                if (asJsonObjectOrNull != null) {
+                    val keys = asJsonObjectOrNull.keys
+                    if (keys.size == 1) {
+                        val first = keys.first()
+                        val second = asJsonObjectOrNull[first].asStringOrNull
+                        if (second != null) {
+                            ws.addPushRule(first, second)
+                        }
+                    } else {
+                        //异常反馈到调用方
+                    }
+                }
+            }
+        }
+        return ok("成功", echo = echo)
+    }
+}

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/action/handlers/SetAllowPushRuleConfig.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/action/handlers/SetAllowPushRuleConfig.kt
@@ -1,9 +1,11 @@
 package moe.fuqiuluo.shamrock.remote.action.handlers
 
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import moe.fuqiuluo.shamrock.remote.action.ActionSession
 import moe.fuqiuluo.shamrock.remote.action.IActionHandler
 import moe.fuqiuluo.shamrock.remote.service.api.WebSocketClientServlet
+import moe.fuqiuluo.shamrock.tools.EmptyJsonString
 import moe.fuqiuluo.shamrock.tools.asJsonObjectOrNull
 import moe.fuqiuluo.shamrock.tools.asStringOrNull
 
@@ -18,7 +20,7 @@ internal object SetAllowPushRuleConfig : IActionHandler() {
 
     operator fun invoke(
         allow: JsonArray,
-        echo: String = "",
+        echo: JsonElement = EmptyJsonString,
         webSocket: WebSocketClientServlet?
     ): String {
         webSocket?.also { ws ->

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/WebSocketClientService.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/WebSocketClientService.kt
@@ -32,19 +32,19 @@ internal class WebSocketClientService(
             }
             val runtime = MobileQQ.getMobileQQ().waitAppRuntime()
             val curUin = runtime.currentAccountUin
-            send(GlobalJson.encodeToString(
+            pushTo(
                 PushMetaEvent(
-                time = System.currentTimeMillis() / 1000,
-                selfId = app.longAccountUin,
-                postType = PostType.Meta,
-                type = MetaEventType.Heartbeat,
-                subType = MetaSubType.Connect,
-                status = BotStatus(
-                    Self("qq", curUin.toLong()), runtime.isLogin, status = "正常", good = true
-                ),
-                interval = 15000
+                    time = System.currentTimeMillis() / 1000,
+                    selfId = app.longAccountUin,
+                    postType = PostType.Meta,
+                    type = MetaEventType.Heartbeat,
+                    subType = MetaSubType.Connect,
+                    status = BotStatus(
+                        Self("qq", curUin.toLong()), runtime.isLogin, status = "正常", good = true
+                    ),
+                    interval = 15000
+                )
             )
-            ))
         }
     }
 


### PR DESCRIPTION
{
  "action": "set_allow_push_rule_config",
  "params" : {
    "allow": [{"user_id":"2216808111"}]
    },
  "echo" : "123456"
}
websocket测试调用json
其“2216808111”可以替换为任意正则表达式，上述接口表达的意思如下：

调用这个接口后，所有消息默认为不推送，除非推送前的“user_id”的值满足正则（在例子中为2216808111），则进行推送。
其中allow为数组，可以放置多组json。
"params" : {
    "allow": [{"user_id":"2216808111"},{"message":"\"at\""}]
    }
多个参数下，user_id与message配置为或关系，message实际值为json结构，但在处理时视为json字符串，第二个配置可以控制消息存在at时推送（此正则不完善）